### PR TITLE
Добавить MessageToReplyId в Response и закомментировать

### DIFF
--- a/EventRegistrator/Application/Services/ResponseManager.cs
+++ b/EventRegistrator/Application/Services/ResponseManager.cs
@@ -23,6 +23,7 @@ namespace EventRegistrator.Application.Services
                 {
                     ChatId = lastEvent.TargetChatId,
                     Text = lastEvent.TemplateText,
+                    MessageToReplyId = lastEvent.PostId,
                     SaveMessageIdCallback = id => { lastEvent.CommentMessageId = id; },
                     ButtonData = new("Скасувати записи", Constants.Cancel),
                 };
@@ -34,6 +35,7 @@ namespace EventRegistrator.Application.Services
                 {
                     ChatId = lastEvent.TargetChatId,
                     Text = lastEvent.TemplateText,
+                    //MessageToReplyId= lastEvent.PostId,
                     MessageToEditId = lastEvent.CommentMessageId,
                     ButtonData = new("Скасувати записи", Constants.Cancel),
                 };


### PR DESCRIPTION
Внесены изменения в ResponseManager.cs:
- Добавлено свойство `MessageToReplyId` в объект `Response` для первого сообщения обновления комментария.
- Закомментирована строка, устанавливающая `MessageToReplyId` для второго сообщения, при этом `MessageToEditId` остается без изменений.